### PR TITLE
Back to square one...

### DIFF
--- a/defaults/probRock.its
+++ b/defaults/probRock.its
@@ -10,7 +10,7 @@
 Mu = 100
 #
 # Number of stages
-NStag = 2
+NStag = 1
 #
 # Specific impulse [s]
 Isp = 450
@@ -110,16 +110,16 @@ tolP = 1e-8
 tolQ = 1e-4
 #
 # Pi lower limits
-pi_min = None, None, None, None
+pi_min = 0.0, 0.0, 0.0
 #
 # Pi upper limits
-pi_max = None, None, None, None
+pi_max = None, None, None
 #
 # Number of divisions in time array [-]
 N = 501
 #
 # Gradient Step Search: P limit constant (see grad_sgra.py) [-]
-GSS_PLimCte = 1.0e5
+GSS_PLimCte = 1.0e9
 #
 # Grad Step Search: step limit closeness tolerance (see grad_sgra.py) [-]
 GSS_stopStepLimTol = 1.0e-2
@@ -148,7 +148,7 @@ we = 0.0
 ###############################################################################
 [solver] # Solver parameters
 #
-guess = 1, 1.5, 1
+guess = 1., 1.5, 1.
 #
 limit = 1.25, 0.4, 0.4
 #

--- a/grad_sgra.py
+++ b/grad_sgra.py
@@ -94,8 +94,8 @@ class stepMngr():
         BadPntMsg = ''
         if Obj > self.Obj0:
             BadPntCode = True
-            BadPntMsg += ("\n-  Obj = {:.4E}".format(Obj) + \
-                         " > {:.4E} = Obj0".format(self.Obj0))
+            BadPntMsg += ("\n-  Obj-Obj0 = {:.4E}".format(Obj-self.Obj0) + \
+                         " > 0")
         if Obj < 0.0:
             BadPntCode = True
             BadPntMsg += ("\n-  Obj = {:.4E} < 0".format(Obj))
@@ -1150,18 +1150,34 @@ def grad(self,corr,alfa_0,retry_grad,stepMan):
     self.log.printL("\nIn grad, Q0 = {:.4E}.".format(self.Q))
     #self.log.printL("NIterGrad = "+str(self.NIterGrad))
 
-    #self.plotSol(opt={'mode':'var','x':corr['x'],'u':corr['u'],'pi':corr['pi']})
-    #input("Olha lá a correção...")
+#    if self.NIterGrad > 99:
+#        newConf = {'left':0.12,'right':0.9,'bottom':0.06,
+#                   'top':.88,'wspace':0.2,'hspace':0.55}
+#        self.log.printL("\nPlotting current sol in interactive mode...")
+#        self.plotSol(mustSaveFig=False, subPlotAdjs=newConf)
+#        self.log.printL("\nPlotting variations in interactive mode...")
+#        self.plotSol(opt={'mode':'var','x':corr['x'],
+#                          'u':corr['u'],'pi':corr['pi']},
+#                     mustSaveFig=False, subPlotAdjs=newConf)
 
     # Calculation of alfa
     alfa, stepMan = self.calcStepGrad(corr,alfa_0,retry_grad,stepMan)
     #alfa = 0.1
     #self.log.printL('\n\nBypass cabuloso: alfa arbitrado em '+str(alfa)+'!\n\n')
-
     self.updtHistGrad(alfa)
 
     self.plotSol(opt={'mode':'lambda'})
     A, B, C = corr['x'], corr['u'], corr['pi']
+
+#    if self.NIterGrad > 99:
+#        self.log.printL("\nPlotting weighted variations in interactive mode...")
+#        newConf = {'left':0.12,'right':0.9,'bottom':0.06,
+#                   'top':.88,'wspace':0.2,'hspace':0.55}
+#        self.plotSol(opt={'mode':'var','x':alfa*A,'u':alfa*B,'pi':alfa*C},
+#                     mustSaveFig=False, subPlotAdjs=newConf)
+#    else:
+#        self.plotSol(opt={'mode':'var','x':alfa*A,'u':alfa*B,'pi':alfa*C})
+
     self.plotSol(opt={'mode':'var','x':alfa*A,'u':alfa*B,'pi':alfa*C})
     #input("@Grad: Waiting for lambda/corrections check...")
 

--- a/interf.py
+++ b/interf.py
@@ -73,7 +73,7 @@ class ITman():
         #'solInitRest.pkl'#'solInit.pkl'#'currSol.pkl'
         self.GRplotSolRate = 1
         self.GRsaveSolRate = 5
-        self.GRpausRate = 1000#1000#10
+        self.GRpausRate = 3000#1000#10
         self.GradHistShowRate = 5
         self.RestPlotSolRate = 5
         self.RestHistShowRate = 5
@@ -216,7 +216,7 @@ class ITman():
                         self.loadAltSolDir = self.loadSolDir
                     else:
                         if inp.lower().endswith('.pkl'):
-                            self.loadSolDir = inp
+                            self.loadAltSolDir = inp
                             keepAsk = False
                         else:
                             self.log.printL('\nSorry, this is not a valid ' + \

--- a/probRock.py
+++ b/probRock.py
@@ -1045,11 +1045,27 @@ class prob(sgra):
         N,s = self.N,self.s
         _,fOrig,fPF = self.calcF()
 
-        Iorig, Ipf = 0.0, 0.0
-        for arc in range(s):
-            Iorig += simp(fOrig[:,arc],N)
-            Ipf += simp(fPF[:,arc],N)
+#        # METHOD 1: simple simpson integration.
+#        Iorig, Ipf = 0.0, 0.0
+#        for arc in range(s):
+#            Iorig += simp(fOrig[:,arc],N)
+#            Ipf += simp(fPF[:,arc],N)
 
+        # METHOD 2: simpson integration, with prints
+        IorigVec, IpfVec = numpy.empty(s), numpy.empty(s)
+        for arc in range(s):
+            IorigVec[arc] = simp(fOrig[:,arc],N)
+            IpfVec[arc] = simp(fPF[:,arc],N)
+
+        Iorig = IorigVec.sum()
+        Ipf = IpfVec.sum()
+
+        self.log.printL("\nIorigVec: "+str(IorigVec))
+        self.log.printL("Iorig: "+str(Iorig))
+        self.log.printL("IpfVec: "+str(IpfVec))
+        self.log.printL("Ipf: "+str(Ipf))
+
+#        # METHOD 3: trapezoidal integration, comparing with simpson
 #        IvecOrig = numpy.empty(s)
 #        IvecPF = numpy.empty(s)
 #

--- a/rest_sgra.py
+++ b/rest_sgra.py
@@ -32,21 +32,22 @@ def calcP(self,mustPlotPint=False):
     #
 
 
-#    vetIP *= self.dt # THIS IS WRONG!! REMOVE IT!!
+    #vetIP *= self.dt # THIS IS WRONG!! REMOVE IT!!
 
-#    PiCondVio = False
-#    piLowLim = self.restrictions['pi_min']
-#    piHighLim = self.restrictions['pi_max']
-#    for i in range(self.s):
-#        # violated here in lower limit condition
-#        if piLowLim[i] is not None and self.pi[i] < piLowLim[i]:
-#            PiCondVio = True; break # already violated, no need to continue
-#        # violated here in upper limit condition
-#        if piHighLim[i] is not None and self.pi[i] > piHighLim[i]:
-#            PiCondVio = True; break # already violated, no need to continue
-#    #
-#    if PiCondVio:
-#        vetIP *= 1e300
+    # TEST FOR VIOLATIONS!
+    PiCondVio = False
+    piLowLim = self.restrictions['pi_min']
+    piHighLim = self.restrictions['pi_max']
+    for i in range(self.s):
+        # violated here in lower limit condition
+        if piLowLim[i] is not None and self.pi[i] < piLowLim[i]:
+            PiCondVio = True; break # already violated, no need to continue
+        # violated here in upper limit condition
+        if piHighLim[i] is not None and self.pi[i] > piHighLim[i]:
+            PiCondVio = True; break # already violated, no need to continue
+    #
+    if PiCondVio:
+        vetIP *= 1e300
 
 #    for arc in range(s):
 #        vetIP[0,arc] = (17.0/48.0) * vetP[0,arc]


### PR DESCRIPTION
Setting the lower limits to 0.0 did not work at all. The program as is
runs very normally, optimizing the solution, up to a very specific
point (I ˜ 1512.4, Q ˜ 0.11, P.M.G. ˜ 29.1%), where the gradStep gets
very small (˜1e-12), which triggers rejections due to unsuficient lo-
wering of ‘I’, and the known dead end.

This very specific point where the program stops optimizing the solu-
tion is independent of the main variable that controls the optimizing
rate, GSS_PLimCte. I tried running the program with GSS_PLimCte =
[1e3, 1e5, 1e7, 1e9], and in all of the runs the program stopped at
the same “point” during the convergence (at different iterations, of
course):

Table 1. “Small steps” transition point vs. GSS_PLimCte
_______________________________________________________
GSS_PLimCte   Iter      I       Q    Payl. Mass Gain
    1e3      ˜1100   1512.4   .117       29.07%
    1e5      ˜320    1512.4   .117       29.08%
    1e7      ˜100    1512.4   .117       29.14%
    1e9       36     1512.3   .102       29.15%
———————————————————————————————————————————————————————

Running the program for a rocket with 30kN thrust generated a similar
problem, but the program stopped in a different point (as it should,
since the initial value of ‘I’ was already lower than 1512.4). With
a single rocket stage, the same result appears, and turning back to
trapezoidal integration for ‘I’ and the vetIP *= dt mistake, the pro-
gram also runs! Muniz even tried the single stage case with only the
trapezoidal integration for ‘I’ and it worked.

This suggests that the trapezoidal integration in f works better with
the rocket problem in general. Indeed, in lmpbvp, the integration me-
thod for phiLamIntCol is the trapezoidal method… I will try this in
the next commit.